### PR TITLE
adding default_tags to platform and tf-backend

### DIFF
--- a/platform/provider.tf
+++ b/platform/provider.tf
@@ -4,6 +4,16 @@ provider "aws" {
     role_arn    = var.assume_roles.mngmt
     external_id = var.external_id
   }
+  default_tags {
+    tags = {
+      Environment     = "platform"
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-platform"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
+  }
 }
 
 provider "aws" {
@@ -12,6 +22,16 @@ provider "aws" {
   assume_role {
     role_arn    = var.assume_roles.users
     external_id = var.external_id
+  }
+  default_tags {
+    tags = {
+      Environment     = "platform"
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-platform"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
   }
 }
 
@@ -22,6 +42,16 @@ provider "aws" {
     role_arn    = var.assume_roles.nonprod
     external_id = var.external_id
   }
+  default_tags {
+    tags = {
+      Environment     = "platform"
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-platform"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
+  }  
 }
 
 provider "aws" {
@@ -31,6 +61,16 @@ provider "aws" {
     role_arn    = var.assume_roles.prod
     external_id = var.external_id
   }
+  default_tags {
+    tags = {
+      Environment     = "platform"
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-platform"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
+  }  
 }
 
 terraform {

--- a/tf-backend/provider.tf
+++ b/tf-backend/provider.tf
@@ -4,6 +4,16 @@ provider "aws" {
     role_arn    = var.assume_roles.mngmt
     external_id = var.external_id
   }
+  default_tags {
+    tags = {
+      Environment     = "tf-backend"
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-platform"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
+  }  
 }
 
 provider "aws" {
@@ -13,6 +23,16 @@ provider "aws" {
     role_arn    = var.assume_roles.users
     external_id = var.external_id
   }
+  default_tags {
+    tags = {
+      Environment     = "tf-backend"
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-platform"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
+  }  
 }
 
 provider "aws" {
@@ -22,6 +42,16 @@ provider "aws" {
     role_arn    = var.assume_roles.nonprod
     external_id = var.external_id
   }
+  default_tags {
+    tags = {
+      Environment     = "tf-backend"
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-platform"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
+  }  
 }
 
 provider "aws" {
@@ -31,6 +61,16 @@ provider "aws" {
     role_arn    = var.assume_roles.prod
     external_id = var.external_id
   }
+  default_tags {
+    tags = {
+      Environment     = "tf-backend"
+      Owner           = "digital-archiving"
+      Terraform       = true
+      TerraformSource = "https://github.com/nationalarchives/tre-terraform-platform"
+      CostCentre      = "56"
+      Role            = "prvt"
+    }
+  }  
 }
 
 terraform {


### PR DESCRIPTION
**This will set default tags that will be inherited to all the resources we create using the provider in platform and tf-backend, unless they are overridden by resource or module level tags.**