### PR TITLE
Changed approval environment naming

### DIFF
--- a/.github/workflows/tre-platform-deployment.yml
+++ b/.github/workflows/tre-platform-deployment.yml
@@ -13,9 +13,10 @@ permissions:
   contents: write
 jobs:
   terraform-deployment:
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@main
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.4
     with:
       environment: ${{ inputs.environment }}
+      environment-for-approval: apply-tf-plan-${{ inputs.environment }}
       tf_dir: ${{ inputs.environment }}
     secrets:
       ROLE_ARN: ${{ secrets.ROLE_ARN }}


### PR DESCRIPTION
Adapted to use new version of `tre-github-actions/.github/workflows/tf-plan-approve-apply.yml` (tagged `0.0.4`). This required new GitHub approval environments be created for `platform` and `tf-backend` (see [tre-terraform-platform/settings/environments](https://github.com/nationalarchives/tre-terraform-platform/settings/environments)).