### PR TITLE
testing roles/policies added to tf_backned managed list

### DIFF
--- a/modules/v2-github-action-testing/output.tf
+++ b/modules/v2-github-action-testing/output.tf
@@ -2,3 +2,8 @@ output "tre_v2_github_action_testing_role_arn" {
   value = aws_iam_role.v2_github_action_testing.arn
   description = "ARN of the v2 GitHub Action Testing Role"
 }
+
+output "tre_v2_github_action_testing_policy_arn" {
+  value = aws_iam_policy.v2_github_action_testing.arn
+  description = "ARN of the v2 GitHub Action Testing Role"
+}

--- a/modules/v2-github-action-testing/v2_github_action_testing_roles.tf
+++ b/modules/v2-github-action-testing/v2_github_action_testing_roles.tf
@@ -11,6 +11,6 @@ resource "aws_iam_policy" "v2_github_action_testing" {
 }
 
 resource "aws_iam_role_policy_attachment" "v2_github_action_testing" {
-  role = aws_iam_role.v2_github_action_testing.arn
+  role = aws_iam_role.v2_github_action_testing.name
   policy_arn = aws_iam_policy.v2_github_action_testing.arn
 }

--- a/tf-backend/locals.tf
+++ b/tf-backend/locals.tf
@@ -74,6 +74,7 @@ locals {
     module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.tf-backend,
     module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.nonprod,
     module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.prod,
+    module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.v2-testing,
     module.tre_management_terraform_roles.tre_terraform_backend_role_arn,
     module.tre_management_terraform_roles.terraform_role_arn
   ]
@@ -83,6 +84,7 @@ locals {
     module.tre_github_actions_open_id_connect.tre_open_id_connect_policies.tf-backend,
     module.tre_github_actions_open_id_connect.tre_open_id_connect_policies.nonprod,
     module.tre_github_actions_open_id_connect.tre_open_id_connect_policies.prod,
+    module.tre_github_actions_open_id_connect.tre_open_id_connect_policies.v2-testing,
     module.tre_management_terraform_roles.tre_terraform_iam_policy,
     module.tre_management_terraform_roles.tre_terraform_policy,
     module.tre_management_terraform_roles.tre_permission_boundary,
@@ -91,13 +93,15 @@ locals {
 
   tre_roles_managed_by_tf_backend_nonprod = [
     module.tre_nonprod_terraform_roles.tre_terraform_backend_role_arn,
-    module.tre_nonprod_terraform_roles.terraform_role_arn
+    module.tre_nonprod_terraform_roles.terraform_role_arn,
+    module.nonprod_v2_github_action_testing_roles.tre_v2_github_action_testing_role_arn
   ]
 
   tre_policies_managed_by_tf_backend_nonprod = [
     module.tre_nonprod_terraform_roles.tre_terraform_iam_policy,
     module.tre_nonprod_terraform_roles.tre_terraform_policy,
     module.tre_nonprod_terraform_roles.tre_permission_boundary,
+    module.nonprod_v2_github_action_testing_roles.tre_v2_github_action_testing_policy_arn,
     "arn:aws:iam::${data.aws_caller_identity.nonprod.account_id}:policy/${var.prefix}-terraform-backend"
   ]
 


### PR DESCRIPTION
As discussed, ran locally to create test roles and policies and adde new roles and policies ARNs to the tf_backend managed list 