### PR TITLE
Creating CW_LogGroup for PTE GitHub Actions Logs

### DIFF
--- a/.github/workflows/tre-platform-deployment.yml
+++ b/.github/workflows/tre-platform-deployment.yml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 jobs:
   terraform-deployment:
-    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.4
+    uses: nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.5
     with:
       environment: ${{ inputs.environment }}
       environment-for-approval: apply-tf-plan-${{ inputs.environment }}

--- a/modules/terraform-plan-logs/cloudwatch.tf
+++ b/modules/terraform-plan-logs/cloudwatch.tf
@@ -1,8 +1,5 @@
-resource "aws_cloudwatch_log_group" "tre-terraform-plan" {
-  for_each = toset(["dev", "test", "int", "staging", "prod", "tf-backend", "platform"])
-  name     = "${var.prefix}-${each.key}-terraform-plan"
+resource "aws_cloudwatch_log_group" "tre-github-actions-logs" {
+  for_each = toset(["dev", "test", "int", "staging", "prod", "tf-backend", "platform", "pte"])
+  name     = "${var.prefix}-${each.key}-github-actions-logs"
 }
 
-resource "aws_cloudwatch_log_group" "tre_github_actions_error" {
-  name = "${var.prefix}-github-actions-error"
-}

--- a/modules/terraform-plan-logs/cloudwatch.tf
+++ b/modules/terraform-plan-logs/cloudwatch.tf
@@ -2,4 +2,3 @@ resource "aws_cloudwatch_log_group" "tre-github-actions-logs" {
   for_each = toset(["dev", "test", "int", "staging", "prod", "tf-backend", "platform", "pte"])
   name     = "${var.prefix}-${each.key}-github-actions-logs"
 }
-


### PR DESCRIPTION
1. Creating a new log group for PTE GitHub Actions Logs
2. Changing log group names to ${var.prefix}-${each.key}-github-actions-logs 
3. Deleting log group for errors 