### PR TITLE
chore: DTE-728 Remove use of external ID

### DIFF
--- a/modules/terraform-roles/data.tf
+++ b/modules/terraform-roles/data.tf
@@ -6,11 +6,6 @@ data "aws_iam_policy_document" "tre_assume_role_terraform" {
       type        = "AWS"
       identifiers = var.roles_can_assume_terraform_role
     }
-    condition {
-      test     = "StringEquals"
-      variable = "sts:ExternalId"
-      values   = [var.external_id]
-    }
   }
 }
 
@@ -21,11 +16,6 @@ data "aws_iam_policy_document" "tre_assume_role_terraform_backend" {
     principals {
       type        = "AWS"
       identifiers = var.roles_can_assume_terraform_backend_role
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "sts:ExternalId"
-      values   = [var.external_id]
     }
   }
 }

--- a/modules/terraform-roles/variables.tf
+++ b/modules/terraform-roles/variables.tf
@@ -47,8 +47,3 @@ variable "account_id" {
   description = "AWS Account ID"
   type        = string
 }
-
-variable "external_id" {
-  description = "Zaizi external ID for role assumption"
-  type        = string
-}

--- a/platform/provider.tf
+++ b/platform/provider.tf
@@ -1,8 +1,7 @@
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn    = var.assume_roles.mngmt
-    external_id = var.external_id
+    role_arn = var.assume_roles.mngmt
   }
   default_tags {
     tags = {
@@ -20,8 +19,7 @@ provider "aws" {
   alias  = "nonprod"
   region = "eu-west-2"
   assume_role {
-    role_arn    = var.assume_roles.nonprod
-    external_id = var.external_id
+    role_arn = var.assume_roles.nonprod
   }
   default_tags {
     tags = {
@@ -39,8 +37,7 @@ provider "aws" {
   alias  = "prod"
   region = "eu-west-2"
   assume_role {
-    role_arn    = var.assume_roles.prod
-    external_id = var.external_id
+    role_arn = var.assume_roles.prod
   }
   default_tags {
     tags = {

--- a/platform/variables.tf
+++ b/platform/variables.tf
@@ -11,8 +11,3 @@ variable "assume_roles" {
     prod    = string
   })
 }
-
-variable "external_id" {
-  description = "External ID for cross account roles"
-  type        = string
-}

--- a/tf-backend/main.tf
+++ b/tf-backend/main.tf
@@ -14,7 +14,6 @@ module "tre_github_actions_open_id_connect" {
 # TRE Environments Terraform Roles Modules
 module "tre_management_terraform_roles" {
   source                                  = "../modules/terraform-roles"
-  external_id                             = var.external_id
   roles_can_assume_terraform_role         = [module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.platform]
   roles_can_assume_terraform_backend_role = [module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.tf-backend]
   prefix                                  = var.prefix
@@ -28,8 +27,7 @@ module "tre_management_terraform_roles" {
 }
 
 module "tre_nonprod_terraform_roles" {
-  source      = "../modules/terraform-roles"
-  external_id = var.external_id
+  source = "../modules/terraform-roles"
   roles_can_assume_terraform_role = [
     module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.platform,
     module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.nonprod
@@ -49,8 +47,7 @@ module "tre_nonprod_terraform_roles" {
 }
 
 module "tre_prod_terraform_roles" {
-  source      = "../modules/terraform-roles"
-  external_id = var.external_id
+  source = "../modules/terraform-roles"
   roles_can_assume_terraform_role = [
     module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.platform,
     module.tre_github_actions_open_id_connect.tre_open_id_connect_roles.prod

--- a/tf-backend/provider.tf
+++ b/tf-backend/provider.tf
@@ -1,8 +1,7 @@
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn    = var.assume_roles.mngmt
-    external_id = var.external_id
+    role_arn = var.assume_roles.mngmt
   }
   default_tags {
     tags = {
@@ -20,8 +19,7 @@ provider "aws" {
   alias  = "nonprod"
   region = "eu-west-2"
   assume_role {
-    role_arn    = var.assume_roles.nonprod
-    external_id = var.external_id
+    role_arn = var.assume_roles.nonprod
   }
   default_tags {
     tags = {
@@ -39,8 +37,7 @@ provider "aws" {
   alias  = "prod"
   region = "eu-west-2"
   assume_role {
-    role_arn    = var.assume_roles.prod
-    external_id = var.external_id
+    role_arn = var.assume_roles.prod
   }
   default_tags {
     tags = {

--- a/tf-backend/variables.tf
+++ b/tf-backend/variables.tf
@@ -12,11 +12,6 @@ variable "assume_roles" {
   })
 }
 
-variable "external_id" {
-  description = "External ID for cross account roles"
-  type        = string
-}
-
 variable "tre_backend_repository" {
   description = "TRE platform repository that requires access to TRE AWS accounts to make changes to Terraform backend"
   type        = list(string)


### PR DESCRIPTION
The trust policy no longer requires at the external ID to be present
The external ID will not be presented in either the tf-backend or platform stack